### PR TITLE
Click on serial log folder opens folder.

### DIFF
--- a/src/tycommander/main_window.cc
+++ b/src/tycommander/main_window.cc
@@ -744,29 +744,31 @@ void MainWindow::updateFirmwareMenus()
 
 void MainWindow::updateSerialLogLink()
 {
-    auto log_filename = current_board_ ? current_board_->serialLogFilename() : "";
-    auto font = serialLogFileLabel->font();
-    if (current_board_ && current_board_->serialLogSize() && !log_filename.isEmpty()) {
-        auto log_foldername = QFileInfo(log_filename).path();
-        auto native_log_foldername = QDir::toNativeSeparators(QFileInfo(log_filename).path() + '/');
-        serialLogFolderLabel->setText(QString("<a href=\"%1\">%2</a>")
-                                     .arg(QUrl::fromLocalFile(log_foldername).toString(), native_log_foldername));
-        serialLogFolderLabel->setToolTip(native_log_foldername);
-        auto native_log_filename = QDir::toNativeSeparators(QFileInfo(log_filename).fileName());
-        auto native_log_filepath = QDir::toNativeSeparators(log_filename);
+    QString log_filename;
+    if (current_board_ && current_board_->serialLogSize())
+        log_filename = current_board_->serialLogFilename();
+
+    QFont link_font = serialLogFileLabel->font();
+    if (!log_filename.isEmpty()) {
+        QFileInfo log_info(log_filename);
+        serialLogDirLabel->setText(QString("<a href=\"%1\">%2</a>")
+                                   .arg(QUrl::fromLocalFile(log_info.path()).toString(),
+                                        QDir::toNativeSeparators(log_info.dir().dirName() + '/')));
+        serialLogDirLabel->setToolTip(QDir::toNativeSeparators(log_info.path()));
         serialLogFileLabel->setText(QString("<a href=\"%1\">%2</a>")
-                                   .arg(QUrl::fromLocalFile(log_filename).toString(), native_log_filename));
-        serialLogFileLabel->setToolTip(native_log_filepath);
-        font.setItalic(false);
+                                    .arg(QUrl::fromLocalFile(log_filename).toString(),
+                                         log_info.fileName()));
+        serialLogFileLabel->setToolTip(QDir::toNativeSeparators(log_filename));
+        link_font.setItalic(false);
     } else {
-        serialLogFolderLabel->setText("");
-        serialLogFolderLabel->setToolTip("");
-        serialLogFileLabel->setText(tr("No serial log available"));
+        serialLogDirLabel->setText(tr("No serial log available"));
+        serialLogDirLabel->setToolTip("");
+        serialLogFileLabel->setText("");
         serialLogFileLabel->setToolTip("");
-        font.setItalic(true);
+        link_font.setItalic(true);
     }
-    serialLogFolderLabel->setFont(font);
-    serialLogFileLabel->setFont(font);
+    serialLogDirLabel->setFont(link_font);
+    serialLogFileLabel->setFont(link_font);
 }
 
 void MainWindow::sendToSelectedBoards(const QString &s)

--- a/src/tycommander/main_window.cc
+++ b/src/tycommander/main_window.cc
@@ -661,7 +661,7 @@ void MainWindow::disableBoardWidgets()
     actionClearSerial->setEnabled(false);
     optionsTab->setEnabled(false);
     actionEnableSerial->setEnabled(false);
-    serialLogFileLabel->clear();
+    updateSerialLogLink();
     ambiguousBoardLabel->setVisible(false);
 
     actionRenameBoard->setEnabled(false);
@@ -744,19 +744,28 @@ void MainWindow::updateFirmwareMenus()
 
 void MainWindow::updateSerialLogLink()
 {
-    auto log_filename = current_board_->serialLogFilename();
+    auto log_filename = current_board_ ? current_board_->serialLogFilename() : "";
     auto font = serialLogFileLabel->font();
-    if (current_board_->serialLogSize() && !log_filename.isEmpty()) {
-        auto native_log_filename = QDir::toNativeSeparators(log_filename);
-        serialLogFileLabel->setText(QString("<a href=\"%1\">%2</a>").arg(log_filename,
-                                                                         native_log_filename));
-        serialLogFileLabel->setToolTip(log_filename);
+    if (current_board_ && current_board_->serialLogSize() && !log_filename.isEmpty()) {
+        auto log_foldername = QFileInfo(log_filename).path();
+        auto native_log_foldername = QDir::toNativeSeparators(QFileInfo(log_filename).path() + '/');
+        serialLogFolderLabel->setText(QString("<a href=\"%1\">%2</a>")
+                                     .arg(QUrl::fromLocalFile(log_foldername).toString(), native_log_foldername));
+        serialLogFolderLabel->setToolTip(native_log_foldername);
+        auto native_log_filename = QDir::toNativeSeparators(QFileInfo(log_filename).fileName());
+        auto native_log_filepath = QDir::toNativeSeparators(log_filename);
+        serialLogFileLabel->setText(QString("<a href=\"%1\">%2</a>")
+                                   .arg(QUrl::fromLocalFile(log_filename).toString(), native_log_filename));
+        serialLogFileLabel->setToolTip(native_log_filepath);
         font.setItalic(false);
     } else {
+        serialLogFolderLabel->setText("");
+        serialLogFolderLabel->setToolTip("");
         serialLogFileLabel->setText(tr("No serial log available"));
         serialLogFileLabel->setToolTip("");
         font.setItalic(true);
     }
+    serialLogFolderLabel->setFont(font);
     serialLogFileLabel->setFont(font);
 }
 

--- a/src/tycommander/main_window.ui
+++ b/src/tycommander/main_window.ui
@@ -425,57 +425,51 @@
              </layout>
             </item>
             <item>
-             <layout class="QHBoxLayout" name="horizontalLayout_ser_logfile_name">
+             <layout class="QHBoxLayout" name="horizontalLayout_6" stretch="1,0,0">
               <item>
-               <widget class="QLabel" name="serialLogFolderLabel">
-                  <property name="sizePolicy">
-                   <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
-                    <horstretch>1</horstretch>
-                    <verstretch>0</verstretch>
-                   </sizepolicy>
-                  </property>
-                  <property name="minimumSize">
-                   <size>
-                    <width>1</width>
-                    <height>0</height>
-                   </size>
-                  </property>
-                  <property name="text">
-                   <string notr="true"></string>
-                  </property>
-                  <property name="openExternalLinks">
-                   <bool>true</bool>
-                  </property>
+               <widget class="QLabel" name="serialLogDirLabel">
+                <property name="sizePolicy">
+                 <sizepolicy hsizetype="Ignored" vsizetype="Preferred">
+                  <horstretch>0</horstretch>
+                  <verstretch>0</verstretch>
+                 </sizepolicy>
+                </property>
+                <property name="text">
+                 <string notr="true">Log Directory</string>
+                </property>
+                <property name="openExternalLinks">
+                 <bool>true</bool>
+                </property>
                </widget>
               </item>
               <item>
-               <widget class="QLabel" name="serialLogFileLabel">
-                  <property name="sizePolicy">
-                   <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
-                    <horstretch>2</horstretch>
-                    <verstretch>0</verstretch>
-                   </sizepolicy>
-                  </property>
-                  <property name="minimumSize">
-                   <size>
-                    <width>40</width>
-                    <height>0</height>
-                   </size>
-                  </property>
-                  <property name="text">
-                   <string notr="true">Serial log in '?'</string>
-                  </property>
-                  <property name="openExternalLinks">
-                   <bool>true</bool>
-                  </property>
-               </widget>
-              </item>
-              <item>
-               <spacer name="horizontalSpacer_2">
+               <spacer name="horizontalSpacer_4">
                 <property name="orientation">
                  <enum>Qt::Horizontal</enum>
                 </property>
+                <property name="sizeHint" stdset="0">
+                 <size>
+                  <width>0</width>
+                  <height>0</height>
+                 </size>
+                </property>
                </spacer>
+              </item>
+              <item>
+               <widget class="QLabel" name="serialLogFileLabel">
+                <property name="minimumSize">
+                 <size>
+                  <width>40</width>
+                  <height>0</height>
+                 </size>
+                </property>
+                <property name="text">
+                 <string notr="true">Log File</string>
+                </property>
+                <property name="openExternalLinks">
+                 <bool>true</bool>
+                </property>
+               </widget>
               </item>
              </layout>
             </item>

--- a/src/tycommander/main_window.ui
+++ b/src/tycommander/main_window.ui
@@ -425,20 +425,59 @@
              </layout>
             </item>
             <item>
-             <widget class="QLabel" name="serialLogFileLabel">
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="Ignored" vsizetype="Preferred">
-                <horstretch>0</horstretch>
-                <verstretch>0</verstretch>
-               </sizepolicy>
-              </property>
-              <property name="text">
-               <string notr="true">Serial log in '?'</string>
-              </property>
-              <property name="openExternalLinks">
-               <bool>true</bool>
-              </property>
-             </widget>
+             <layout class="QHBoxLayout" name="horizontalLayout_ser_logfile_name">
+              <item>
+               <widget class="QLabel" name="serialLogFolderLabel">
+                  <property name="sizePolicy">
+                   <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+                    <horstretch>1</horstretch>
+                    <verstretch>0</verstretch>
+                   </sizepolicy>
+                  </property>
+                  <property name="minimumSize">
+                   <size>
+                    <width>1</width>
+                    <height>0</height>
+                   </size>
+                  </property>
+                  <property name="text">
+                   <string notr="true"></string>
+                  </property>
+                  <property name="openExternalLinks">
+                   <bool>true</bool>
+                  </property>
+               </widget>
+              </item>
+              <item>
+               <widget class="QLabel" name="serialLogFileLabel">
+                  <property name="sizePolicy">
+                   <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+                    <horstretch>2</horstretch>
+                    <verstretch>0</verstretch>
+                   </sizepolicy>
+                  </property>
+                  <property name="minimumSize">
+                   <size>
+                    <width>40</width>
+                    <height>0</height>
+                   </size>
+                  </property>
+                  <property name="text">
+                   <string notr="true">Serial log in '?'</string>
+                  </property>
+                  <property name="openExternalLinks">
+                   <bool>true</bool>
+                  </property>
+               </widget>
+              </item>
+              <item>
+               <spacer name="horizontalSpacer_2">
+                <property name="orientation">
+                 <enum>Qt::Horizontal</enum>
+                </property>
+               </spacer>
+              </item>
+             </layout>
             </item>
             <item>
              <layout class="QHBoxLayout" name="horizontalLayout_4">


### PR DESCRIPTION
This splits the serial log file path into 2 parts, folder and filename. A click on the folder part opens the folder, a click on the file part opens the file.

This should also make paths with spaces behave properly (currently broken).

This allows easy access to an older log file.